### PR TITLE
유저 체크 시 birthday type string으로 변경

### DIFF
--- a/app/services/service_user.py
+++ b/app/services/service_user.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+from app.common.constants import DATEFORMAT
 from app.entities.entity_user_fcm_token import UserFcmToken
 from app.entities.entity_users import Users
 
@@ -58,7 +61,7 @@ class UserService:
                 "phone_number": user.user_phone_number,
                 "user_profile_img_url": None,
                 "delete_flag": user.user_delete_flag,
-                "birthday": user.user_birthday
+                "birthday": user.user_birthday.strftime(DATEFORMAT)
             }
 
         return None;


### PR DESCRIPTION
기존 user의 birthday가 null 값으로 들어올 때에는 몰랐는데, birthday 가 정상적으로 저장되면서 생기는 문제로 보임
user 검색 시 결과를 반환할 때 date 형식을 serialize할 수 없다는 에러가 발생하여 birthday를 String 으로 변경 